### PR TITLE
Added the ability to add padding between character frames in the export.

### DIFF
--- a/Assets/Create Character Menu/Save Character Popup/Scripts/SaveCharacterManager.cs
+++ b/Assets/Create Character Menu/Save Character Popup/Scripts/SaveCharacterManager.cs
@@ -32,6 +32,7 @@ public class SaveCharacterManager : MonoBehaviour
     [SerializeField] TMP_Dropdown sizeDropdown;
     [SerializeField] TMP_Dropdown animationDropdown;
     [SerializeField] AnimationDataDropdown animationDataDropdown;
+    [SerializeField] TMP_InputField paddingInputField;
     [SerializeField] Button saveCharacterButton;
 
     [Space]
@@ -162,6 +163,12 @@ public class SaveCharacterManager : MonoBehaviour
         }
 
         //finalTexture = SpriteManager.ExtractTextureRegion(finalTexture, 0, 32, 383, 32);
+
+        if (int.TryParse(paddingInputField.text, out int padding) && padding > 0)
+        {
+            int characterSize = GetCurrentSizeFromDropdown();
+            finalTexture = SpriteManager.AddPaddingToTexture(finalTexture, padding, characterSize);
+        }
 
         SaveCharacterToFile(finalTexture);
         UpdateScores();
@@ -411,6 +418,21 @@ public class SaveCharacterManager : MonoBehaviour
                 return "48x48";
             default:
                 return "";
+        }
+    }
+
+    int GetCurrentSizeFromDropdown()
+    {
+        switch (sizeDropdown.value)
+        {
+            case 0:
+                return 16;
+            case 1:
+                return 32;
+            case 2:
+                return 48;
+            default:
+                return 0;
         }
     }
 

--- a/Assets/Scenes/Create Character.unity
+++ b/Assets/Scenes/Create Character.unity
@@ -1925,7 +1925,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 764, y: 500}
+  m_SizeDelta: {x: 764, y: 600}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &213255440
 MonoBehaviour:
@@ -5847,12 +5847,13 @@ RectTransform:
   - {fileID: 1459186340}
   - {fileID: 1911367496}
   - {fileID: 1788071173}
+  - {fileID: 2066793689}
   - {fileID: 1559513000}
   m_Father: {fileID: 470128515}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -66.3785}
+  m_AnchoredPosition: {x: 0, y: -13}
   m_SizeDelta: {x: 0, y: -132.757}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &455842923
@@ -6059,8 +6060,9 @@ MonoBehaviour:
   sizeDropdown: {fileID: 3565683680007033134}
   animationDropdown: {fileID: 981998534}
   animationDataDropdown: {fileID: 470128517}
+  paddingInputField: {fileID: 2066793690}
   saveCharacterButton: {fileID: 3798328174423830453}
-  defaultBackgroundSize: {x: 764, y: 500}
+  defaultBackgroundSize: {x: 764, y: 600}
   backgroundCharacterSavedSize: {x: 600, y: 300}
 --- !u!114 &470128517
 MonoBehaviour:
@@ -13012,6 +13014,161 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 3164177266001784105, guid: 90582517470cd704cbe73b020c724415, type: 3}
   m_PrefabInstance: {fileID: 1124100559}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1131559430
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1131559431}
+  - component: {fileID: 1131559434}
+  - component: {fileID: 1131559433}
+  - component: {fileID: 1131559432}
+  m_Layer: 5
+  m_Name: Placeholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1131559431
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1131559430}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1733175895}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.0025024414, y: -2.9059}
+  m_SizeDelta: {x: -0.005, y: -5.8119}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1131559432
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1131559430}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 1
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!114 &1131559433
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1131559430}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Padding...
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: e8c9e41e987e8a849ac0e28a5dd4b55c, type: 2}
+  m_sharedMaterial: {fileID: -573558151868498788, guid: e8c9e41e987e8a849ac0e28a5dd4b55c, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 2164260863
+  m_fontColor: {r: 1, g: 1, b: 1, a: 0.5}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 30
+  m_fontSizeBase: 30
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 2
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 1
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1131559434
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1131559430}
+  m_CullTransparentMesh: 1
 --- !u!114 &1131638274 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1729962269422073366, guid: 4d9d82cac20b8d74e94fdbd1341e0b38, type: 3}
@@ -17239,7 +17396,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 381.7405, y: -268.41}
+  m_AnchoredPosition: {x: 381.7405, y: -371.82}
   m_SizeDelta: {x: 597.7123, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1559513001
@@ -20058,6 +20215,58 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1731119572}
   m_CullTransparentMesh: 1
+--- !u!1 &1733175894
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1733175895}
+  - component: {fileID: 1733175896}
+  m_Layer: 5
+  m_Name: Text Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1733175895
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1733175894}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1131559431}
+  - {fileID: 1887256633}
+  m_Father: {fileID: 2066793689}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.44999695, y: -0.5}
+  m_SizeDelta: {x: -47.14, y: -13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1733175896
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1733175894}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding: {x: -8, y: -5, z: -8, w: -5}
+  m_Softness: {x: 0, y: 0}
 --- !u!1 &1740911252
 GameObject:
   m_ObjectHideFlags: 0
@@ -21295,6 +21504,140 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1863872345}
+  m_CullTransparentMesh: 1
+--- !u!1 &1887256632
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1887256633}
+  - component: {fileID: 1887256635}
+  - component: {fileID: 1887256634}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1887256633
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1887256632}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1733175895}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.0025024414, y: -2.9059}
+  m_SizeDelta: {x: -0.005, y: -5.8119}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1887256634
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1887256632}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\u200B"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 5c5fd55af9243e846ac123ffd6322a48, type: 2}
+  m_sharedMaterial: {fileID: -833680924259879142, guid: 5c5fd55af9243e846ac123ffd6322a48, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 35
+  m_fontSizeBase: 35
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 1
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1887256635
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1887256632}
   m_CullTransparentMesh: 1
 --- !u!1 &1891168083
 GameObject:
@@ -23097,6 +23440,181 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   saveCharacterManager: {fileID: 470128516}
   infoMenuManager: {fileID: 9136178541413836587}
+--- !u!1 &2066793688
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2066793689}
+  - component: {fileID: 2066793692}
+  - component: {fileID: 2066793691}
+  - component: {fileID: 2066793690}
+  m_Layer: 5
+  m_Name: Padding Input Field
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2066793689
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2066793688}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1733175895}
+  m_Father: {fileID: 455842922}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 381.7405, y: -262.615}
+  m_SizeDelta: {x: 296.43, y: 88.41}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2066793690
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2066793688}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2da0c512f12947e489f739169773d7ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 2
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 202329551, guid: 1a2ffa019e468c144a7c052f738783e2, type: 3}
+    m_PressedSprite: {fileID: 202329551, guid: 1a2ffa019e468c144a7c052f738783e2, type: 3}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2066793691}
+  m_TextViewport: {fileID: 1733175895}
+  m_TextComponent: {fileID: 1887256634}
+  m_Placeholder: {fileID: 1131559433}
+  m_VerticalScrollbar: {fileID: 0}
+  m_VerticalScrollbarEventHandler: {fileID: 0}
+  m_LayoutGroup: {fileID: 0}
+  m_ScrollSensitivity: 1
+  m_ContentType: 0
+  m_InputType: 0
+  m_AsteriskChar: 42
+  m_KeyboardType: 0
+  m_LineType: 0
+  m_HideMobileInput: 0
+  m_HideSoftKeyboard: 0
+  m_CharacterValidation: 0
+  m_RegexValue: 
+  m_GlobalPointSize: 14
+  m_CharacterLimit: 0
+  m_OnEndEdit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSubmit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSelect:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnDeselect:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnEndTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnTouchScreenKeyboardStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_CustomCaretColor: 0
+  m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
+  m_Text: 
+  m_CaretBlinkRate: 0.85
+  m_CaretWidth: 1
+  m_ReadOnly: 0
+  m_RichText: 1
+  m_GlobalFontAsset: {fileID: 11400000, guid: e8c9e41e987e8a849ac0e28a5dd4b55c, type: 2}
+  m_OnFocusSelectAll: 1
+  m_ResetOnDeActivation: 1
+  m_RestoreOriginalTextOnEscape: 1
+  m_isRichTextEditingAllowed: 0
+  m_LineLimit: 0
+  m_InputValidator: {fileID: 0}
+--- !u!114 &2066793691
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2066793688}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -1348722830, guid: dd34f4ce743abc943884b1c665eec107, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2066793692
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2066793688}
+  m_CullTransparentMesh: 1
 --- !u!1 &2075359450
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/SpriteManager.cs
+++ b/Assets/Scripts/SpriteManager.cs
@@ -154,4 +154,44 @@ public class SpriteManager : MonoBehaviour
 
         File.WriteAllBytes(Path.Combine(path, fileName + ".png"), bytes);
     }
+
+
+    public static Texture2D AddPaddingToTexture(Texture2D texture, int padding, int characterSize)
+    {
+        int verticalSize = characterSize * 2;
+        int rows = texture.height / verticalSize;
+        int columns = texture.width / characterSize;
+        int newWidth = texture.width + (columns-1) * padding;
+        int newHeight = texture.height + (rows-1) * padding;
+        var paddedTexture = new Texture2D(newWidth, newHeight)
+        {
+            filterMode = FilterMode.Point,
+            wrapMode = TextureWrapMode.Clamp
+        };
+        paddedTexture.SetPixels32(new Color32[newWidth * newHeight]);
+
+        for (int y = 0; y < rows; y++)
+        {
+            int sourceY = y * verticalSize;
+            int destinationX = 0;
+            int destinationY = y * (verticalSize + padding);
+
+            for (int x = 0; x < columns; x++)
+            {
+                int sourceX = x * characterSize;
+                var pixels = texture.GetPixels(sourceX, sourceY, characterSize, verticalSize);
+                paddedTexture.SetPixels(destinationX, destinationY, characterSize, verticalSize, pixels);
+
+                // This exception is to keep the shopping cart from getting split from padding
+                if (y == 11 && x >= 24 && x % 2 == 0)
+                    destinationX += characterSize;
+                else
+                    destinationX += characterSize + padding;
+            }
+        }
+
+        paddedTexture.Apply();
+
+        return paddedTexture;
+    }
 }


### PR DESCRIPTION
Some engines, even when using point filtering, bleed pixels from the next frame into the current one. This PR adds the ability for the user to add padding between the sprite frames when exporting the final sheet to prevent bleeding.

If the user desires to not add padding it will ignore calling this code and behave as before. If they desire to add padding, it creates a new "padded" texture and stamps the sprites to the padded positions and then returns it to be exported.

The padding applies horizontally and vertically.

Here are some images of the results and one edge case that was addressed.


Unpadded (default):

<img width="288" height="69" alt="Unpadded" src="https://github.com/user-attachments/assets/3d5d982f-918a-401f-b346-51bee7855036" />


Padded 2 pixels between sprites:

<img width="298" height="69" alt="Padded" src="https://github.com/user-attachments/assets/4ea7857b-fcd3-416f-9e82-2d2e18cfe7e6" />


New UI Option:

<img width="838" height="498" alt="Screenshot 2025-07-27 002120" src="https://github.com/user-attachments/assets/71494e39-29d5-48e9-a626-0fa604eedff5" />
<img width="838" height="498" alt="Screenshot 2025-07-27 002128" src="https://github.com/user-attachments/assets/b913646b-3cba-4a5c-86ec-785f85676937" />


One issue that needed to be addressed was that the padding would split the shopping cart. I simply skipped adding padding for those sprites.

Broken:
<img width="265" height="78" alt="PossibleIssue" src="https://github.com/user-attachments/assets/1640f14f-2785-46ce-b329-3712ad19869e" />

Fixed (3 player sprites to show padding is on them, but not the cart):
<img width="424" height="90" alt="IssueFixed" src="https://github.com/user-attachments/assets/61783aa2-9765-4fd9-a762-66abd64126e6" />


Example full output with 2 pixels padding:

<img width="2798" height="1958" alt="Son" src="https://github.com/user-attachments/assets/86aaa0f6-2c4c-434a-a5d0-4e19331d6aa5" />